### PR TITLE
 Adds support for NSSL microphysics (2 and 3-moment) from WRF (mp_physics=18)

### DIFF
--- a/ReadConfParameters.f90
+++ b/ReadConfParameters.f90
@@ -123,10 +123,20 @@ endif
 
 str%nht=5
 if (str%MP_PHYSICS==9) str%nht=6
+if (str%MP_PHYSICS==18) str%nht=6
 if (str%MP_PHYSICS==30) str%nht=6 !added by oue 2017/07/17 for ICON
 if (str%MP_PHYSICS==40) str%nht=8 !added by oue 2017/07/21 for RAMS
 if (str%MP_PHYSICS==50) str%nht=6 !added by DW  2017/10/30 for P3
 if (str%MP_PHYSICS==70) str%nht=2 !added by oue 2018 April, for SAM warm bin
+
+! hack to read optional input for model name: WRF, CM1, SAM, RAMS, etc.
+! If none, default is WRF
+read(id,'(a)') inputline
+if ( inputline(1:1).ne.'#' ) then
+  read(inputline,'(a)') str%ModelName
+else
+  str%ModelName = 'WRF'
+endif
 !
 inputline='#'
 do while (inputline(1:1).eq.'#')
@@ -327,12 +337,14 @@ str%WRF_MP_PHYSICS_20_InputFiles(4)=Trim(str%path_back_scatt_libs)//"../SBM_20/t
 endif
 
 !==========================================================
-!- Massages added by oue April 2018
+!- Messages added by oue April 2018
      if (str%MP_PHYSICS==8) then
 write(*,*) 'Selected microphysics: 8 (WRF Thompson bulk moment)'
 else if (str%MP_PHYSICS==9) then
 write(*,*) 'Selected microphysics: 9 (WRF Milbranndt-Yau)'
 if(str%snow_spherical==0) write(*,*) ' Non spherical snow'
+else if (str%MP_PHYSICS==18) then
+write(*,*) 'Selected microphysics: 18 (WRF NSSL-2M)'
 else if (str%MP_PHYSICS==10) then
 write(*,*) 'Selected microphysics: 10 (WRF Morrison 2 moment)'
 if(str%MP10HailOption==1) write(*,*) ' Use hail instead of graupel'

--- a/ReadInpWRFFile.f90
+++ b/ReadInpWRFFile.f90
@@ -557,6 +557,247 @@
   return
   end subroutine ReadInpWRF_MP_PHYSICS_09
   !!
+  subroutine ReadInpWRF_MP_PHYSICS_18(InpFile,str,status)
+  Use netcdf
+  Use typeSizes
+  Use wrf_rvar_mod
+  Use wrf_var_mod
+  Implicit None
+  !
+  Character(len=*),Intent(in)                              :: InpFile
+  Type(wrf_var_mp18),Intent(InOut)                         :: str
+  Integer,Intent(out)                                      :: status
+  !
+  Type(wrf_rvar_mp18)                                      :: strr
+  integer                                                  :: nDims, nVars
+  integer                                                  :: ncid, iVar
+  Character(len=nf90_max_name), Allocatable , Dimension(:) :: var_names
+  Character(len=nf90_max_name)                             :: name, err_msg
+    !
+    !
+    ! define strr dimensions
+    strr%nt=str%nt
+    strr%nx=str%nx
+    strr%ny=str%ny
+    strr%nz=str%nz
+    !
+    ! allocate strr vars
+    call allocate_wrf_rvar_mp18(strr)
+    call initialize_wrf_rvar_mp18(strr)
+    !
+    !Open the file
+    status=  nf90_open(Trim(InpFile), NF90_NOWRITE, ncid)
+    If (status/=0) Then
+      err_msg = 'Error in my_nf90_open'
+      Goto 999
+    End If
+    !
+    ! Get info on nDims and nVars
+    status= nf90_inquire(ncid, nDims, nVars)
+    If (status/=0) Then
+      err_msg = 'Error in my_nf90_inquire'
+      Goto 999
+    End If
+    !
+    !
+    ! Create arrays that contain the variables
+    Allocate(var_names(1:nVars))
+    !
+    Do  iVar=1,nVars
+      !
+      status= nf90_inquire_variable(ncid, iVar, name=name)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_inquire_variable: '//name
+        Goto 999
+      Endif
+      !
+      Select Case (Trim(Adjustl(name)))
+      !
+      Case ('QCLOUD')
+      status=nf90_get_var(ncid,iVar,strr%QCLOUD)
+      str%QCLOUD = dble(strr%QCLOUD)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QCLOUD'
+        Goto 999
+      End If
+      !
+      Case ('QRAIN')
+      status=nf90_get_var(ncid,iVar,strr%QRAIN)
+      str%QRAIN  = dble(strr%QRAIN)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QRAIN'
+        Goto 999
+      End If
+      !
+      Case ('QICE')
+      status=nf90_get_var(ncid,iVar,strr%QICE)
+      str%QICE  = dble(strr%QICE)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QICE'
+        Goto 999
+      End If
+      !
+      Case ('QSNOW')
+      status=nf90_get_var(ncid,iVar,strr%QSNOW)
+      str%QSNOW  = dble(strr%QSNOW)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QSNOW'
+        Goto 999
+      End If
+      !
+      Case ('QGRAUP')
+      status=nf90_get_var(ncid,iVar,strr%QGRAUP)
+      str%QGRAUP  = dble(strr%QGRAUP)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QGRAUP'
+        Goto 999
+      End If
+      !
+      Case ('QHAIL')
+      status=nf90_get_var(ncid,iVar,strr%QHAIL)
+      str%QHAIL  = dble(strr%QHAIL)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QHAIL'
+        Goto 999
+      End If
+      !
+      Case ('QNDROP') ! NSSL uses qndrop instead of qncloud
+      status=nf90_get_var(ncid,iVar,strr%QNCLOUD)
+      str%QNCLOUD  = dble(strr%QNCLOUD)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QNCLOUD'
+        Goto 999
+      End If
+      !
+      Case ('QNRAIN')
+      status=nf90_get_var(ncid,iVar,strr%QNRAIN)
+      str%QNRAIN  = dble(strr%QNRAIN)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QNRAIN'
+        Goto 999
+      End If
+      !
+      Case ('QNICE')
+      status=nf90_get_var(ncid,iVar,strr%QNICE)
+      str%QNICE  = dble(strr%QNICE)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QNICE'
+        Goto 999
+      End If
+      !
+      Case ('QNSNOW')
+      status=nf90_get_var(ncid,iVar,strr%QNSNOW)
+      str%QNSNOW  = dble(strr%QNSNOW)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QNSNOW'
+        Goto 999
+      End If
+      !
+      Case ('QNGRAUPEL')
+      status=nf90_get_var(ncid,iVar,strr%QNGRAUP)
+      str%QNGRAUP  = dble(strr%QNGRAUP)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QNGRAUPEL'
+        Goto 999
+      End If
+      !
+      Case ('QNHAIL')
+      status=nf90_get_var(ncid,iVar,strr%QNHAIL)
+      str%QNHAIL  = dble(strr%QNHAIL)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QNHAIL'
+        Goto 999
+      End If
+
+      Case ('QVGRAUPEL')
+      status=nf90_get_var(ncid,iVar,strr%QVGRAUP)
+      str%QVGRAUP  = dble(strr%QVGRAUP)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QVGRAUPEL'
+        Goto 999
+      End If
+      !
+      Case ('QVHAIL')
+      status=nf90_get_var(ncid,iVar,strr%QVHAIL)
+      str%QVHAIL  = dble(strr%QVHAIL)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QVHAIL'
+        Goto 999
+      End If
+
+      Case ('QZRAIN')
+      status=nf90_get_var(ncid,iVar,strr%QZRAIN)
+      str%QZRAIN  = dble(strr%QZRAIN)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QZRAIN'
+        Goto 999
+      End If
+      Case ('QZGRAUPEL')
+      status=nf90_get_var(ncid,iVar,strr%QZGRAUP)
+      str%QZGRAUP  = dble(strr%QZGRAUP)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QZGRAUPEL'
+        Goto 999
+      End If
+      !
+      Case ('QZHAIL')
+      status=nf90_get_var(ncid,iVar,strr%QZHAIL)
+      str%QZHAIL  = dble(strr%QZHAIL)
+      If (status/=0) Then
+        err_msg = 'Error in my_nf90_get_var: QZHAIL'
+        Goto 999
+      End If
+      !
+      End Select
+      !
+    End Do
+    !
+    Deallocate(var_names)
+    
+999 If (status.Ne.0) Then
+      write(*,*)  err_msg
+      Call Exit(1)
+    Else
+      status=nf90_close(ncid)
+    Endif
+    !
+    !
+    go to 101
+    write(*,*) '-----------------'
+    write(*,*) '---mix ratio---'
+    write(*,*) 'cloud',minval(str%qcloud),maxval(str%qcloud)
+    write(*,*) 'rain',minval(str%qrain),maxval(str%qrain)
+    write(*,*) 'ice',minval(str%qice),maxval(str%qice)
+    write(*,*) 'snow',minval(str%qsnow),maxval(str%qsnow)
+    write(*,*) 'graupel',minval(str%qgraup),maxval(str%qgraup)
+    write(*,*) 'hail',minval(str%qhail),maxval(str%qhail)
+    
+    write(*,*) '---concentr---'
+    write(*,*) 'cloud',minval(str%qncloud),maxval(str%qncloud)
+    write(*,*) 'rain',minval(str%qnrain),maxval(str%qnrain)
+    write(*,*) 'ice',minval(str%qnice),maxval(str%qnice)
+    write(*,*) 'snow',minval(str%qnsnow),maxval(str%qnsnow)
+    write(*,*) 'graupel',minval(str%qngraup),maxval(str%qngraup)
+    write(*,*) 'hail',minval(str%qnhail),maxval(str%qnhail)
+
+    write(*,*) '---volume---'
+    write(*,*) 'graupel',minval(str%qvgraup),maxval(str%qvgraup)
+    write(*,*) 'hail',minval(str%qvhail),maxval(str%qvhail)
+
+    write(*,*) '---refl---'
+    write(*,*) 'rain',minval(str%qzrain),maxval(str%qzrain)
+    write(*,*) 'graupel',minval(str%qzgraup),maxval(str%qzgraup)
+    write(*,*) 'hail',minval(str%qzhail),maxval(str%qzhail)
+    ! 
+    !write(*,*) '-----------------'
+    !pause
+    101 continue
+    !
+    call deallocate_wrf_rvar_mp18(strr)   
+    ! 
+  return
+  end subroutine ReadInpWRF_MP_PHYSICS_18
+  !!
   !!
   subroutine ReadInpWRF_MP_PHYSICS_10(InpFile,str,status)
   Use netcdf

--- a/crsim.f90
+++ b/crsim.f90
@@ -163,6 +163,7 @@
   Type(wrf_var_mp09)             :: mp09
   Type(wrf_var_mp08)             :: mp08 !added by oue 2016/09/19
   Type(wrf_var_mp10)             :: mp10
+  Type(wrf_var_mp18)             :: mp18
   Type(wrf_var_mp20)             :: mp20
   Type(wrf_var_mp30)             :: mp30 !added by oue 2017/07/17 for ICON
   Type(wrf_var_mp40)             :: mp40 !added by oue 2017/07/21 for RAMS
@@ -174,6 +175,7 @@
   Type(env_var)                  :: env 
   Type(hydro_var)                :: hydro
   Type(hydro20_var)              :: hydro20
+  Type(hydro18_var)              :: hydro18
   Type(hydro50_var)              :: hydro50 ! added by DW 2017/10/30 for P3
   Type(hydro70_var)              :: hydro70 ! added by oue for SAM warm bin
   !
@@ -453,6 +455,102 @@
       !write(*,*) 'snow',minval(hydro%qnhydro(:,:,:,4),mask=hydro%qnhydro(:,:,:,4)>0.d0),maxval(hydro%qnhydro(:,:,:,4))
       !write(*,*) 'graup',minval(hydro%qnhydro(:,:,:,5),mask=hydro%qnhydro(:,:,:,5)>0.d0),maxval(hydro%qnhydro(:,:,:,5))
       !write(*,*) 'hail',minval(hydro%qnhydro(:,:,:,6),mask=hydro%qnhydro(:,:,:,6)>0.d0),maxval(hydro%qnhydro(:,:,:,6))
+  
+      !
+      !write(*,*) '--------------------------------------'
+      !write(*,*) '--------------------------------------'
+      !!pause
+  
+    endif
+    !-------------------------------------------------------------------------------------------------------------------
+    !-------------------------------------------------------------------------------------------------------------------
+    ! conf%MP_PHYSICS==18
+    if (conf%MP_PHYSICS==18) then ! NSSL 2-moment scheme
+      WRFmpInputFile=conf%WRFInputFile
+      mp18%nx=nx
+      mp18%ny=ny
+      mp18%nz=nz
+      mp18%nt=nt
+      !
+      call allocate_wrf_var_mp18(mp18)
+      call initialize_wrf_var_mp18(mp18)
+       write(0,*) 'Reading from file: modelname = ',conf%ModelName
+      if ( trim(conf%ModelName) == 'WRF' ) then
+        call ReadInpWRF_MP_PHYSICS_18(Trim(WRFmpInputFile),mp18,status)
+      elseif ( conf%ModelName == 'CM1' ) then
+!        call ReadInpCM1_MP_PHYSICS_18(Trim(WRFmpInputFile),mp18,status)
+      elseif ( conf%ModelName == 'COMMAS' ) then
+!        call ReadInpCOMMAS_MP_PHYSICS_18(Trim(WRFmpInputFile),mp18,status)
+! convert number, etc. from m^-3 to kg^-1: divide by env%rho_d
+      else
+        call ReadInpWRF_MP_PHYSICS_18(Trim(WRFmpInputFile),mp18,status)
+      endif
+      !
+      write(*,*) '-----------------'
+      write(*,*) '---mix ratio---'
+      write(*,*) 'cloud',minval(mp18%qcloud),maxval(mp18%qcloud)
+      write(*,*) 'rain',minval(mp18%qrain),maxval(mp18%qrain)
+      write(*,*) 'ice',minval(mp18%qice),maxval(mp18%qice)
+      write(*,*) 'snow',minval(mp18%qsnow),maxval(mp18%qsnow)
+      write(*,*) 'graupel',minval(mp18%qgraup),maxval(mp18%qgraup)
+      write(*,*) 'hail',minval(mp18%qhail),maxval(mp18%qhail)
+  
+      write(*,*) '---concentr---'
+      write(*,*) 'cloud',minval(mp18%qncloud),maxval(mp18%qncloud)
+      write(*,*) 'rain',minval(mp18%qnrain),maxval(mp18%qnrain)
+      write(*,*) 'ice',minval(mp18%qnice),maxval(mp18%qnice)
+      write(*,*) 'snow',minval(mp18%qnsnow),maxval(mp18%qnsnow)
+      write(*,*) 'graupel',minval(mp18%qngraup),maxval(mp18%qngraup)
+      write(*,*) 'hail',minval(mp18%qnhail),maxval(mp18%qnhail)
+
+      write(*,*) '---volume---'
+      write(*,*) 'graupel',minval(mp18%qvgraup),maxval(mp18%qvgraup)
+      write(*,*) 'hail',minval(mp18%qvhail),maxval(mp18%qvhail)
+
+      write(*,*) '---reflectivity---'
+      write(*,*) 'rain',minval(mp18%qzrain),maxval(mp18%qzrain)
+      write(*,*) 'graupel',minval(mp18%qzgraup),maxval(mp18%qzgraup)
+      write(*,*) 'hail',minval(mp18%qzhail),maxval(mp18%qzhail)
+  
+      write(*,*) '-----------------'
+  
+      hydro18%nx=env%nx
+      hydro18%ny=env%ny
+      hydro18%nz=env%nz
+      hydro18%nht=nsc
+      !----------------------------------------
+      !----------------------------------------
+      call allocate_hydro18_var(hydro18)
+      call initialize_hydro18_var(hydro18)
+      !
+      call get_hydro18_vars(conf,mp18,hydro18)
+      call deallocate_wrf_var_mp18(mp18)
+      !
+      write(*,*) '--------------------------------------'
+      write(*,*) '-------------mass-------------------------'
+      write(*,*) 'cloud',minval(hydro18%qhydro(:,:,:,1)),maxval(hydro18%qhydro(:,:,:,1))
+      write(*,*) 'rain ',minval(hydro18%qhydro(:,:,:,2)),maxval(hydro18%qhydro(:,:,:,2))
+      write(*,*) 'ice  ',minval(hydro18%qhydro(:,:,:,3)),maxval(hydro18%qhydro(:,:,:,3))
+      write(*,*) 'snow ',minval(hydro18%qhydro(:,:,:,4)),maxval(hydro18%qhydro(:,:,:,4))
+      write(*,*) 'graup',minval(hydro18%qhydro(:,:,:,5)),maxval(hydro18%qhydro(:,:,:,5))
+      write(*,*) 'hail',minval(hydro18%qhydro(:,:,:,6)),maxval(hydro18%qhydro(:,:,:,6))
+      write(*,*) '-------------conc-------------------------'
+      !
+  
+      write(*,*) 'cloud ',minval(hydro18%qnhydro(:,:,:,1)),maxval(hydro18%qnhydro(:,:,:,1))
+      write(*,*) 'rain ',minval(hydro18%qnhydro(:,:,:,2)),maxval(hydro18%qnhydro(:,:,:,2))
+      write(*,*) 'ice  ',minval(hydro18%qnhydro(:,:,:,3)),maxval(hydro18%qnhydro(:,:,:,3))
+      write(*,*) 'snow ',minval(hydro18%qnhydro(:,:,:,4)),maxval(hydro18%qnhydro(:,:,:,4))
+      write(*,*) 'graup',minval(hydro18%qnhydro(:,:,:,5)),maxval(hydro18%qnhydro(:,:,:,5))
+      write(*,*) 'hail',minval(hydro18%qnhydro(:,:,:,6)),maxval(hydro18%qnhydro(:,:,:,6))
+      !
+      write(*,*) '--------------volume------------------------'
+      write(*,*) 'graup',minval(hydro18%qvhydro(:,:,:,5)),maxval(hydro18%qvhydro(:,:,:,5))
+      write(*,*) 'hail',minval(hydro18%qvhydro(:,:,:,6)),maxval(hydro18%qvhydro(:,:,:,6))
+      write(*,*) '---------------refl-----------------------'
+      write(*,*) 'rain',minval(hydro18%qzhydro(:,:,:,2)),maxval(hydro18%qzhydro(:,:,:,2))
+      write(*,*) 'graup',minval(hydro18%qzhydro(:,:,:,5)),maxval(hydro18%qzhydro(:,:,:,5))
+      write(*,*) 'hail',minval(hydro18%qzhydro(:,:,:,6)),maxval(hydro18%qzhydro(:,:,:,6))
   
       !
       !write(*,*) '--------------------------------------'
@@ -1017,7 +1115,7 @@
     ! and dimensions of other variables needed (mout) 
     !
     !-----------------------------------------
-    if ( (conf%MP_PHYSICS==9) .or. &
+    if ( (conf%MP_PHYSICS==9)  .or.  &
          (conf%MP_PHYSICS==10) .or. (conf%MP_PHYSICS==8) .or. &
          (conf%MP_PHYSICS==30) .or. (conf%MP_PHYSICS==40).or. & ! modified by oue 2016/09/19, 2017/07/17 ICON, RAMS
          (conf%MP_PHYSICS==75) .or. (conf%MP_PHYSICS==80)) then ! modified by oue 2018/06 SAM, Apr 2020 for CM1
@@ -1031,6 +1129,22 @@
         mout%ny=hydro%ny
         mout%nz=hydro%nz
         mout%nht=hydro%nht
+      ENDIF
+      !
+    endif
+    !-----------------------------------------
+    !-----------------------------------------
+    if (  (conf%MP_PHYSICS==18) ) then ! 
+      rmout%nx=hydro18%nx
+      rmout%ny=hydro18%ny
+      rmout%nz=hydro18%nz
+      rmout%nht=hydro18%nht
+      !
+      IF (conf%radID/=1) THEN ! if radID/=1 include polarimet. vars
+        mout%nx=hydro18%nx
+        mout%ny=hydro18%ny
+        mout%nz=hydro18%nz
+        mout%nht=hydro18%nht
       ENDIF
       !
     endif
@@ -1216,6 +1330,7 @@
               LutFileName = ''
   
               if (conf%MP_PHYSICS== 9) qq=hydro%qhydro(ix,iy,iz,iht)
+              if (conf%MP_PHYSICS==18) qq=hydro18%qhydro(ix,iy,iz,iht)
               if (conf%MP_PHYSICS==10) qq=hydro%qhydro(ix,iy,iz,iht)
               if (conf%MP_PHYSICS==20) qq=scatt_type(iht)%qq(ix,iy,iz)
               if (conf%MP_PHYSICS== 8) qq=hydro%qhydro(ix,iy,iz,iht) !Added by oue 2016/09/19
@@ -1455,6 +1570,8 @@
                   (conf%MP_PHYSICS==30).or.(conf%MP_PHYSICS==40).or.(conf%MP_PHYSICS==75) .or.&
                   (conf%MP_PHYSICS==80)) then !Modified by oue 2016/09/19, 2017/07/17, 2018/06/17 ICON,RAMS,SAM, Apr 2020 CM1
                 qsum=Sum(hydro%qhydro(ix,iy,iz,1:nsc))  
+              elseif (conf%MP_PHYSICS==18) then ! added by erm for NSSL
+                qsum=Sum(hydro18%qhydro(ix,iy,iz,1:nsc))  
               elseif (conf%MP_PHYSICS==50) then ! added by DW for P3
                 qsum=Sum(hydro50%qhydro(ix,iy,iz,1:nsc)) ! added by DW for P3
               ! 
@@ -1528,6 +1645,7 @@
                 do iht=1,nsc ! nsc == 5 in small example
     
                   if (conf%MP_PHYSICS== 9) qq=hydro%qhydro(ix,iy,iz,iht)
+                  if (conf%MP_PHYSICS==18) qq=hydro18%qhydro(ix,iy,iz,iht)
                   if (conf%MP_PHYSICS==10) qq=hydro%qhydro(ix,iy,iz,iht)
                   if (conf%MP_PHYSICS==20) qq=scatt_type(iht)%qq(ix,iy,iz)
                   if (conf%MP_PHYSICS== 8) qq=hydro%qhydro(ix,iy,iz,iht) !Added by oue 2016/09/19
@@ -1557,9 +1675,10 @@
                       !AUG2019
                       ! AT NOTE: two parameteres relative for airborne obs enter
                       ! into processing subrs: conf% airborne and elevx
+
                       call processing(iht, conf,elevx,env%w(ix,iy,iz),&
                                       env%temp(ix,iy,iz),env%rho_d(ix,iy,iz), env%rho_d(ix,iy,1), &
-                                      hydro%qhydro(ix,iy,iz,iht),hydro%qnhydro(ix,iy,iz,iht),&
+                                      hydro%qhydro(ix,iy,iz,iht),hydro%qnhydro(ix,iy,iz,iht),     &
                                       spectra%VNyquist,spectra%NOISE_1km,spectra%NFFT,spectra%Nave,&
                                       dist_from_radar,w_r,sw_dyn,&
                                       zhh,zvv,zvh,RHOhvc,&
@@ -1569,6 +1688,23 @@
                                       ceilo_back_true,ceilo_ext,&
                                       mpl_back_true,mpl_ext,&
                                       spectra_bins,zhh_spectra,zvh_spectra,zvv_spectra) 
+                    endif
+
+                    if (conf%MP_PHYSICS==18) then ! erm
+                      call processing_nssl(iht, conf,elevx,env%w(ix,iy,iz),&
+                                      env%temp(ix,iy,iz),env%rho_d(ix,iy,iz), env%rho_d(ix,iy,1), &
+                                      hydro18%qhydro(ix,iy,iz,iht),hydro18%qnhydro(ix,iy,iz,iht),&
+                                      hydro18%qvhydro(ix,iy,iz,iht),hydro18%qzhydro(ix,iy,iz,iht), &
+                                      spectra%VNyquist,spectra%NOISE_1km,spectra%NFFT,spectra%Nave,&
+                                      dist_from_radar,w_r,sw_dyn,&
+                                      zhh,zvv,zvh,RHOhvc,&
+                                      dvh,d_dvh,Dopp,&
+                                      Kdp,Adp,Ah,Av,&
+                                      diff_back_phase,&
+                                      ceilo_back_true,ceilo_ext,&
+                                      mpl_back_true,mpl_ext,&
+                                      spectra_bins,zhh_spectra,zvh_spectra,zvv_spectra) 
+
                     endif
                     !
                     if (conf%MP_PHYSICS==50) then ! added by DW 2017/10/30 P3
@@ -2119,6 +2255,7 @@
       !- Liquid water content (cloud + rain) ! [kg/m3] water content 
       if (conf%MP_PHYSICS== 8)  lwc=(hydro%qhydro(:,:,:,1)+hydro%qhydro(:,:,:,2))*env%rho_d 
       if (conf%MP_PHYSICS== 9)  lwc=(hydro%qhydro(:,:,:,1)+hydro%qhydro(:,:,:,2))*env%rho_d 
+      if (conf%MP_PHYSICS== 18) lwc=(hydro18%qhydro(:,:,:,1)+hydro18%qhydro(:,:,:,2))*env%rho_d 
       if (conf%MP_PHYSICS== 10) lwc=(hydro%qhydro(:,:,:,1)+hydro%qhydro(:,:,:,2))*env%rho_d 
       if (conf%MP_PHYSICS== 30) lwc=(hydro%qhydro(:,:,:,1)+hydro%qhydro(:,:,:,2))*env%rho_d 
       if (conf%MP_PHYSICS== 40) lwc=(hydro%qhydro(:,:,:,1)+hydro%qhydro(:,:,:,2)&
@@ -2187,6 +2324,7 @@
       if ((iht>=1) .and. (iht<=nht)) then
         if (conf%MP_PHYSICS== 8)  qqc=hydro%qhydro(:,:,:,iht) !added by oue 2016/09/19
         if (conf%MP_PHYSICS== 9)  qqc=hydro%qhydro(:,:,:,iht)
+        if (conf%MP_PHYSICS==18)  qqc=hydro18%qhydro(:,:,:,iht)
         if (conf%MP_PHYSICS==10)  qqc=hydro%qhydro(:,:,:,iht)
         if (conf%MP_PHYSICS==20)  qqc=scatt_type(iht)%qq
         if (conf%MP_PHYSICS==30)  qqc=hydro%qhydro(:,:,:,iht) !added by oue 2017/07/17 ICON
@@ -2200,6 +2338,7 @@
         do isc=1,nht
           if (conf%MP_PHYSICS== 8) qqc=qqc+hydro%qhydro(:,:,:,isc) !added by oue 2016/09/19
           if (conf%MP_PHYSICS== 9) qqc=qqc+hydro%qhydro(:,:,:,isc)
+          if (conf%MP_PHYSICS==18) qqc=qqc+hydro18%qhydro(:,:,:,isc)
           if (conf%MP_PHYSICS==10) qqc=qqc+hydro%qhydro(:,:,:,isc)
           if (conf%MP_PHYSICS==20) qqc=qqc+scatt_type(isc)%qq
           if (conf%MP_PHYSICS==30) qqc=qqc+hydro%qhydro(:,:,:,isc) !added by oue 2017/07/17 ICON
@@ -2275,6 +2414,7 @@
     !
     if (conf%MP_PHYSICS==08) call deallocate_hydro_var(hydro) !added by oue 2016/09/19
     if (conf%MP_PHYSICS==09) call deallocate_hydro_var(hydro)
+    if (conf%MP_PHYSICS==18) call deallocate_hydro18_var(hydro18)
     if (conf%MP_PHYSICS==10) call deallocate_hydro_var(hydro)
     if (conf%MP_PHYSICS==30) call deallocate_hydro_var(hydro) !added by oue 2017/07/17 ICON
     if (conf%MP_PHYSICS==40) call deallocate_hydro_var(hydro) !added by oue 2017/07/21 RAMS

--- a/crsim_mod.f90
+++ b/crsim_mod.f90
@@ -235,6 +235,7 @@ Integer            :: InpProfile_flag       ! Check if use Input profile data fi
 Character(len=365) :: InputProfile          ! the name of the profiling data file for SAM (netcdf) 
 !
 Integer            :: airborne              ! ==0 for radar looking up  (no airborne) and /= 0 otherwise
+Character(len=20)  :: ModelName             ! Default model to WRF; or CM1, SAM, COMMAS
 
 !
 End Type conf_var
@@ -280,6 +281,20 @@ real*8, Dimension(:,:,:,:),Allocatable    :: qhydro  ! hydrometeor mixing ratio 
 real*8, Dimension(:,:,:,:),Allocatable    :: qnhydro ! hydro number concentrat. [1/kg] 
 !
 End Type hydro_var
+!!-------------------------------
+Type hydro18_var
+!
+integer                 :: nx
+integer                 :: ny
+integer                 :: nz
+integer                 :: nht
+!
+real*8, Dimension(:,:,:,:),Allocatable    :: qhydro  ! hydrometeor mixing ratio [kg/kg] 1-cloud, 2-rain, 3-ice, 4-snow 5-graupel
+real*8, Dimension(:,:,:,:),Allocatable    :: qnhydro ! hydro number concentrat. [1/kg] 
+real*8, Dimension(:,:,:,:),Allocatable    :: qvhydro ! hydro volume [m^3/kg] 
+real*8, Dimension(:,:,:,:),Allocatable    :: qzhydro ! reflectivity [m^6/kg] 
+!
+End Type hydro18_var
 !!-------------------------------
 ! Type hydro50_var is added by DW 2017/10/30 for P3
 Type hydro50_var
@@ -629,6 +644,56 @@ str%nht=0
 !
 return
 end subroutine deallocate_hydro_var
+!!
+!!
+subroutine allocate_hydro18_var(str)
+Implicit None
+Type(hydro18_var),Intent(InOut)        :: str
+Integer                              :: nx,ny,nz,nht
+!
+nx=str%nx
+ny=str%ny
+nz=str%nz
+nht=str%nht
+!
+Allocate(str%qhydro(nx,ny,nz,nht))
+Allocate(str%qnhydro(nx,ny,nz,nht))
+Allocate(str%qvhydro(nx,ny,nz,nht))
+Allocate(str%qzhydro(nx,ny,nz,nht))
+!
+return
+end subroutine allocate_hydro18_var
+!!
+subroutine initialize_hydro18_var(str)
+Use phys_param_mod, ONLY: zero
+Implicit None
+Type(hydro18_var),Intent(InOut)        :: str
+!
+!
+str%qhydro=zero
+str%qnhydro=zero
+str%qvhydro=zero
+str%qzhydro=zero
+!
+return
+end subroutine initialize_hydro18_var
+!!
+subroutine deallocate_hydro18_var(str)
+Implicit None
+Type(hydro18_var),Intent(InOut)        :: str
+!
+Deallocate(str%qhydro)
+Deallocate(str%qnhydro)
+Deallocate(str%qvhydro)
+Deallocate(str%qzhydro)
+!
+str%nx=0
+str%ny=0
+str%nz=0
+str%nht=0
+!
+return
+end subroutine deallocate_hydro18_var
 !!
 !subroutine allocate_hydro50_var(str) is added by DW 2017/10/30 for P3
 subroutine allocate_hydro50_var(str)

--- a/wrf_rvar_mod.f90
+++ b/wrf_rvar_mod.f90
@@ -70,7 +70,7 @@ real*4,Dimension(:,:,:),Allocatable        :: xlong ! [deg] longitude; west is n
 real*4,Dimension(:,:,:,:),Allocatable      :: tke   ! [m^2/s^2]  turbulence kinetic energy
 !
 End Type wrf_rvar
-
+!!
 Type wrf_rvar_mp09
 !
 integer                  :: nt
@@ -93,6 +93,37 @@ real*4,Dimension(:,:,:,:),Allocatable      :: qngraup ! [1/kg] Graupel  Number c
 real*4,Dimension(:,:,:,:),Allocatable      :: qnhail  ! [1/kg] Hail  Number concentration
 !
 End Type wrf_rvar_mp09
+!!
+!!
+Type wrf_rvar_mp18
+!
+integer                  :: nt
+integer                  :: nx
+integer                  :: ny
+integer                  :: nz
+!
+real*4,Dimension(:,:,:,:),Allocatable      :: qcloud ! [kg/kg] Cloud water mixing ratio
+real*4,Dimension(:,:,:,:),Allocatable      :: qrain  ! [kg/kg] Rain water mixing ratio
+real*4,Dimension(:,:,:,:),Allocatable      :: qice   ! [kg/kg] Ice water mixing ratio
+real*4,Dimension(:,:,:,:),Allocatable      :: qsnow  ! [kg/kg] Snow water mixing ratio
+real*4,Dimension(:,:,:,:),Allocatable      :: qgraup ! [kg/kg] Graupel water mixing ratio
+real*4,Dimension(:,:,:,:),Allocatable      :: qhail  ! [kg/kg] Hail water mixing ratio
+
+real*4,Dimension(:,:,:,:),Allocatable      :: qncloud ! [1/kg] Cloud Number concentration
+real*4,Dimension(:,:,:,:),Allocatable      :: qnrain  ! [1/kg] Rain Number concentration
+real*4,Dimension(:,:,:,:),Allocatable      :: qnice   ! [1/kg] Ice  Number concentration
+real*4,Dimension(:,:,:,:),Allocatable      :: qnsnow  ! [1/kg] Snow  Number concentration
+real*4,Dimension(:,:,:,:),Allocatable      :: qngraup ! [1/kg] Graupel  Number concentration
+real*4,Dimension(:,:,:,:),Allocatable      :: qnhail  ! [1/kg] Hail  Number concentration
+
+real*4,Dimension(:,:,:,:),Allocatable      :: qvgraup ! [m^3/kg] Graupel volume
+real*4,Dimension(:,:,:,:),Allocatable      :: qvhail  ! [m^3/kg] Hail volume
+
+real*4,Dimension(:,:,:,:),Allocatable      :: qzgraup ! [m^6/kg] Graupel reflectivity
+real*4,Dimension(:,:,:,:),Allocatable      :: qzhail  ! [m^6/kg] Hail reflectivity
+real*4,Dimension(:,:,:,:),Allocatable      :: qzrain  ! [m^6/kg] rain reflectivity
+!
+End Type wrf_rvar_mp18
 !!
 Type wrf_rvar_mp10
 !
@@ -363,6 +394,41 @@ Allocate(str%qnhail(nx,ny,nz,nt))
 !
 return
 end subroutine allocate_wrf_rvar_mp09
+
+!!
+subroutine allocate_wrf_rvar_mp18(str)
+Implicit None
+Type(wrf_rvar_mp18),Intent(InOut)     :: str
+Integer                              :: nt,nx,ny,nz
+!
+nt=str%nt
+nx=str%nx
+ny=str%ny
+nz=str%nz
+!
+Allocate(str%qcloud(nx,ny,nz,nt))
+Allocate(str%qrain(nx,ny,nz,nt))
+Allocate(str%qice(nx,ny,nz,nt))
+Allocate(str%qsnow(nx,ny,nz,nt))
+Allocate(str%qgraup(nx,ny,nz,nt))
+Allocate(str%qhail(nx,ny,nz,nt))
+!
+Allocate(str%qncloud(nx,ny,nz,nt))
+Allocate(str%qnrain(nx,ny,nz,nt))
+Allocate(str%qnice(nx,ny,nz,nt))
+Allocate(str%qnsnow(nx,ny,nz,nt))
+Allocate(str%qngraup(nx,ny,nz,nt))
+Allocate(str%qnhail(nx,ny,nz,nt))
+!
+Allocate(str%qvgraup(nx,ny,nz,nt))
+Allocate(str%qvhail(nx,ny,nz,nt))
+
+Allocate(str%qzgraup(nx,ny,nz,nt))
+Allocate(str%qzhail(nx,ny,nz,nt))
+Allocate(str%qzrain(nx,ny,nz,nt))
+!
+return
+end subroutine allocate_wrf_rvar_mp18
 !!
 subroutine allocate_wrf_rvar_mp10(str)
 Implicit None
@@ -659,6 +725,36 @@ str%qnhail=m999
 return
 end subroutine initialize_wrf_rvar_mp09
 !!
+!!
+subroutine initialize_wrf_rvar_mp18(str)
+Implicit None
+Type(wrf_rvar_mp18),Intent(InOut)     :: str
+ReaL*4,parameter                     :: m999=-999.e0
+!
+str%qcloud=m999
+str%qrain=m999
+str%qice=m999
+str%qsnow=m999
+str%qgraup=m999
+str%qhail=m999
+!
+str%qncloud=m999
+str%qnrain=m999
+str%qnice=m999
+str%qnsnow=m999
+str%qngraup=m999
+str%qnhail=m999
+
+str%qvgraup=m999
+str%qvhail=m999
+
+str%qzgraup=m999
+str%qzhail=m999
+str%qzrain=m999
+!
+return
+end subroutine initialize_wrf_rvar_mp18
+!!
 subroutine initialize_wrf_rvar_mp10(str)
 Implicit None
 Type(wrf_rvar_mp10),Intent(InOut)     :: str
@@ -911,6 +1007,40 @@ str%nz=0
 !
 return
 end subroutine deallocate_wrf_rvar_mp09
+!!
+!!
+subroutine deallocate_wrf_rvar_mp18(str)
+Implicit None
+Type(wrf_rvar_mp18),Intent(InOut)     :: str
+!
+Deallocate(str%qcloud)
+Deallocate(str%qrain)
+Deallocate(str%qice)
+Deallocate(str%qsnow)
+Deallocate(str%qgraup)
+Deallocate(str%qhail)
+!
+Deallocate(str%qncloud)
+Deallocate(str%qnrain)
+Deallocate(str%qnice)
+Deallocate(str%qnsnow)
+Deallocate(str%qngraup)
+Deallocate(str%qnhail)
+
+Deallocate(str%qvgraup)
+Deallocate(str%qvhail)
+
+Deallocate(str%qzgraup)
+Deallocate(str%qzhail)
+Deallocate(str%qzrain)
+!
+str%nt=0
+str%nx=0
+str%ny=0
+str%nz=0
+!
+return
+end subroutine deallocate_wrf_rvar_mp18
 !!
 subroutine deallocate_wrf_rvar_mp10(str)
 Implicit None

--- a/wrf_var_mod.f90
+++ b/wrf_var_mod.f90
@@ -113,6 +113,34 @@ real*8,Dimension(:,:,:,:),Allocatable      :: qnhail  ! [1/kg] Hail  Number conc
 !
 End Type wrf_var_mp09
 !!
+Type wrf_var_mp18
+!
+integer                  :: nt
+integer                  :: nx
+integer                  :: ny
+integer                  :: nz
+!
+real*8,Dimension(:,:,:,:),Allocatable      :: qcloud ! [kg/kg] Cloud water mixing ratio
+real*8,Dimension(:,:,:,:),Allocatable      :: qrain  ! [kg/kg] Rain water mixing ratio
+real*8,Dimension(:,:,:,:),Allocatable      :: qice   ! [kg/kg] Ice water mixing ratio
+real*8,Dimension(:,:,:,:),Allocatable      :: qsnow  ! [kg/kg] Snow water mixing ratio
+real*8,Dimension(:,:,:,:),Allocatable      :: qgraup ! [kg/kg] Graupel water mixing ratio
+real*8,Dimension(:,:,:,:),Allocatable      :: qhail  ! [kg/kg] Hail water mixing ratio
+
+real*8,Dimension(:,:,:,:),Allocatable      :: qncloud ! [1/kg] Cloud Number concentration
+real*8,Dimension(:,:,:,:),Allocatable      :: qnrain  ! [1/kg] Rain Number concentration
+real*8,Dimension(:,:,:,:),Allocatable      :: qnice   ! [1/kg] Ice  Number concentration
+real*8,Dimension(:,:,:,:),Allocatable      :: qnsnow  ! [1/kg] Snow  Number concentration
+real*8,Dimension(:,:,:,:),Allocatable      :: qngraup ! [1/kg] Graupel  Number concentration
+real*8,Dimension(:,:,:,:),Allocatable      :: qnhail  ! [1/kg] Hail  Number concentration
+real*8,Dimension(:,:,:,:),Allocatable      :: qvgraup ! [m^3/kg] Graupel volume
+real*8,Dimension(:,:,:,:),Allocatable      :: qvhail  ! [m^3/kg] Hail volume
+real*8,Dimension(:,:,:,:),Allocatable      :: qzgraup ! [m^6/kg] Graupel reflectivity
+real*8,Dimension(:,:,:,:),Allocatable      :: qzhail  ! [m^6/kg] Hail reflectivity
+real*8,Dimension(:,:,:,:),Allocatable      :: qzrain  ! [m^6/kg] Rain reflectivity
+!
+End Type wrf_var_mp18
+!!
 Type wrf_var_mp10
 !
 integer                  :: nt
@@ -381,6 +409,42 @@ Allocate(str%qnhail(nx,ny,nz,nt))
 !
 return
 end subroutine allocate_wrf_var_mp09
+!!
+!!
+subroutine allocate_wrf_var_mp18(str)
+Implicit None
+Type(wrf_var_mp18),Intent(InOut)     :: str
+Integer                              :: nt,nx,ny,nz
+!
+nt=str%nt
+nx=str%nx
+ny=str%ny
+nz=str%nz
+!
+Allocate(str%qcloud(nx,ny,nz,nt))
+Allocate(str%qrain(nx,ny,nz,nt))
+Allocate(str%qice(nx,ny,nz,nt))
+Allocate(str%qsnow(nx,ny,nz,nt))
+Allocate(str%qgraup(nx,ny,nz,nt))
+Allocate(str%qhail(nx,ny,nz,nt))
+!
+Allocate(str%qncloud(nx,ny,nz,nt))
+Allocate(str%qnrain(nx,ny,nz,nt))
+Allocate(str%qnice(nx,ny,nz,nt))
+Allocate(str%qnsnow(nx,ny,nz,nt))
+Allocate(str%qngraup(nx,ny,nz,nt))
+Allocate(str%qnhail(nx,ny,nz,nt))
+
+Allocate(str%qvgraup(nx,ny,nz,nt))
+Allocate(str%qvhail(nx,ny,nz,nt))
+
+Allocate(str%qzgraup(nx,ny,nz,nt))
+Allocate(str%qzhail(nx,ny,nz,nt))
+Allocate(str%qzrain(nx,ny,nz,nt))
+!
+return
+end subroutine allocate_wrf_var_mp18
+
 !!
 subroutine allocate_wrf_var_mp10(str)
 Implicit None
@@ -675,6 +739,36 @@ str%qnhail=m999
 return
 end subroutine initialize_wrf_var_mp09
 !!
+!!
+subroutine initialize_wrf_var_mp18(str)
+Implicit None
+Type(wrf_var_mp18),Intent(InOut)     :: str
+real*8,parameter                     :: m999=-999.d0
+!
+str%qcloud=m999
+str%qrain=m999
+str%qice=m999
+str%qsnow=m999
+str%qgraup=m999
+str%qhail=m999
+!
+str%qncloud=m999
+str%qnrain=m999
+str%qnice=m999
+str%qnsnow=m999
+str%qngraup=m999
+str%qnhail=m999
+
+str%qvgraup=m999
+str%qvhail=m999
+
+str%qzgraup=m999
+str%qzhail=m999
+str%qzrain=m999
+!
+return
+end subroutine initialize_wrf_var_mp18
+!!
 subroutine initialize_wrf_var_mp10(str)
 Implicit None
 Type(wrf_var_mp10),Intent(InOut)     :: str
@@ -927,6 +1021,39 @@ str%nz=0
 !
 return
 end subroutine deallocate_wrf_var_mp09
+!!
+subroutine deallocate_wrf_var_mp18(str)
+Implicit None
+Type(wrf_var_mp18),Intent(InOut)     :: str
+!
+Deallocate(str%qcloud)
+Deallocate(str%qrain)
+Deallocate(str%qice)
+Deallocate(str%qsnow)
+Deallocate(str%qgraup)
+Deallocate(str%qhail)
+!
+Deallocate(str%qncloud)
+Deallocate(str%qnrain)
+Deallocate(str%qnice)
+Deallocate(str%qnsnow)
+Deallocate(str%qngraup)
+Deallocate(str%qnhail)
+!
+Deallocate(str%qvgraup)
+Deallocate(str%qvhail)
+
+Deallocate(str%qzgraup)
+Deallocate(str%qzhail)
+Deallocate(str%qzrain)
+!
+str%nt=0
+str%nx=0
+str%ny=0
+str%nz=0
+!
+return
+end subroutine deallocate_wrf_var_mp18
 !!
 subroutine deallocate_wrf_var_mp10(str)
 Implicit None


### PR DESCRIPTION
Setting the microphysics option to 18 enables NSSL bulk microphysics (2 or 3 moment) from WRF as input. It also uses the predicted graupel and hail volumes to set the graupel and hail ice densities.